### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/hosts/dellxps13/home.nix
+++ b/hosts/dellxps13/home.nix
@@ -77,10 +77,10 @@ in
   # Nicely reload system units when changing configs
   systemd.user.startServices = "sd-switch";
 
-  # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
+  # https://wiki.nixos.org/wiki/FAQ/When_do_I_update_stateVersion
   home.stateVersion = "23.05";
 
-  # https://nixos.wiki/wiki/Home_Manager#Usage_on_non-NixOS_Linux
+  # https://wiki.nixos.org/wiki/Home_Manager#Usage_on_non-NixOS_Linux
   targets.genericLinux.enable = true;
 
   roles.git.githubIdentityFile = config.age.secrets.github-id-rsa.path;


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️